### PR TITLE
Support multi-root installations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
 
 gem 'rake', '10.4.2'
-gem 'puppet-lint', '1.1.0'
+gem 'puppet-lint', '2.0.2'
 gem 'rspec-puppet', '2.3.0'
 gem 'rspec-system-puppet', '2.2.1'
 gem 'puppetlabs_spec_helper', '0.9.1'

--- a/Rakefile
+++ b/Rakefile
@@ -21,8 +21,12 @@ exclude_paths = [
   "vendor/**/*",
   "spec/**/*",
 ]
-PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
+
+PuppetLint::RakeTask.new :lint do |config|
+  config.relative = true
+  config.ignore_paths = exclude_paths
+end
 
 desc "Run syntax, lint, and spec tests."
 task :test => [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,7 +102,7 @@ class aptly (
     }
   }
 
-  $aptly_cmd = "/usr/bin/aptly -config ${config_file}"
+  $aptly_cmd = '/usr/bin/aptly'
 
   # Hiera support
   create_resources('::aptly::repo', $aptly_repos)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,8 +21,8 @@
 #   See http://www.aptly.info/#configuration
 #   Default: {}
 #
-# [*create_config*]
-#   Whether to create a config file or not
+# [*single_root*]
+#   Whether we plan to use one aptly root or not.
 #   Default: true
 #
 # [*repo*]
@@ -52,7 +52,7 @@ class aptly (
   $config_file     = '/etc/aptly.conf',
   $config          = {},
   $config_contents = undef,
-  $create_config   = true,
+  $single_root     = true,
   $repo            = true,
   $key_server      = undef,
   $user            = 'root',
@@ -62,7 +62,7 @@ class aptly (
 
   validate_absolute_path($config_file)
   validate_hash($config)
-  validate_bool($create_config)
+  validate_bool($single_root)
   validate_hash($aptly_repos)
   validate_hash($aptly_mirrors)
   validate_bool($repo)
@@ -90,7 +90,7 @@ class aptly (
     ensure  => $package_ensure,
   }
 
-  if $create_config {
+  if $single_root {
     $config_file_contents = $config_contents ? {
       undef   => inline_template("<%= Hash[@config.sort].to_pson %>\n"),
       default => $config_contents,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,11 @@
 # [*config_file*]
 #   Absolute path to the configuration file. Defaults to
 #   `/etc/aptly.conf`.
-
+#
+# [*config_dir*]
+#   Absolute path to the configuration directory, used in multi root
+#   setups. Defaults to `/etc/aptly.conf.d`.
+#
 # [*config_contents*]
 #   Contents of the config file.
 #   Default: undef
@@ -50,6 +54,7 @@
 class aptly (
   $package_ensure  = present,
   $config_file     = '/etc/aptly.conf',
+  $config_dir      = '/etc/aptly.conf.d',
   $config          = {},
   $config_contents = undef,
   $single_root     = true,
@@ -99,6 +104,10 @@ class aptly (
     file { $config_file:
       ensure  => file,
       content => $config_file_contents,
+    }
+  } else {
+    file { $config_dir:
+      ensure => directory,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class aptly (
 ) {
 
   validate_absolute_path($config_file)
+  validate_absolute_path($config_dir)
   validate_hash($config)
   validate_bool($single_root)
   validate_hash($aptly_repos)

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -90,9 +90,10 @@ define aptly::mirror (
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title} ${location} ${release} ${components}")
 
   # Since the create and show commands don't share a common set of
-  # options, we need to extract the config
-  if has_key($cli_options, '-config') {
-    $config_string = "-config=${cli_options['-config']}"
+  # options, we need to extract the config if it has been specified.
+  $config_path_specified = has_key($cli_options, '-config')
+  if $config_path_specified {
+    $config_string="-config=${cli_options['-config']}"
   } else {
     $config_string = ''
   }

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -89,9 +89,17 @@ define aptly::mirror (
   $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title} ${location} ${release} ${components}")
 
+  # Since the create and show commands don't share a common set of
+  # options, we need to extract the config
+  if has_key($cli_options, '-config') {
+    $config_string = "-config=${cli_options['-config']}"
+  } else {
+    $config_string = ''
+  }
+
   exec { "aptly_mirror_create-${title}":
     command     => $cmd_string,
-    unless      => "${aptly_cmd} show ${title} >/dev/null",
+    unless      => "${aptly_cmd} show ${config_string} ${title} >/dev/null",
     user        => $::aptly::user,
     require     => $exec_aptly_mirror_create_require,
     environment => $environment,

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -53,13 +53,6 @@ define aptly::mirror (
   validate_array($environment)
   validate_hash($cli_options)
 
-  $default_cli_options = {
-    '-architectures'    => '',
-    '-with-sources'     => false,
-    '-with-udebs'       => false,
-    '-force-components' => false,
-  }
-
   include ::aptly
 
   $gpg_cmd = '/usr/bin/gpg --no-default-keyring --keyring trustedkeys.gpg'
@@ -93,7 +86,7 @@ define aptly::mirror (
     ]
   }
 
-  $cli_options_string = join(reject(join_keys_to_values(merge($default_cli_options, $cli_options), '='), '.*=$'), ' ')
+  $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title} ${location} ${release} ${components}")
 
   exec { "aptly_mirror_create-${title}":

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -36,7 +36,7 @@
 #   Example: ['http_proxy=http://127.0.0.2:3128']
 #   Default: []
 #
-# [*cmd_options*]
+# [*cli_options*]
 #   Hash containing the command line options that will be passed to aptly.
 #
 define aptly::mirror (
@@ -46,14 +46,14 @@ define aptly::mirror (
   $release          = $::lsbdistcodename,
   $repos            = [],
   $environment      = [],
-  $cmd_options      = {},
+  $cli_options      = {},
 ) {
   validate_string($keyserver)
   validate_array($repos)
   validate_array($environment)
-  validate_hash($cmd_options)
+  validate_hash($cli_options)
 
-  $default_cmd_options = {
+  $default_cli_options = {
     '-architectures'    => '',
     '-with-sources'     => false,
     '-with-udebs'       => false,
@@ -93,8 +93,8 @@ define aptly::mirror (
     ]
   }
 
-  $cmd_options_string = join(reject(join_keys_to_values(merge($default_cmd_options, $cmd_options), '='), '.*=$'), ' ')
-  $cmd_string         = rstrip("${aptly_cmd} create ${cmd_options_string} ${title} ${location} ${release} ${components}")
+  $cli_options_string = join(reject(join_keys_to_values(merge($default_cli_options, $cli_options), '='), '.*=$'), ' ')
+  $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title} ${location} ${release} ${components}")
 
   exec { "aptly_mirror_create-${title}":
     command     => $cmd_string,

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -85,13 +85,11 @@ define aptly::mirror (
 
     $exec_aptly_mirror_create_require = [
       Package['aptly'],
-      File['/etc/aptly.conf'],
       Exec["aptly_mirror_gpg-${title}"],
     ]
   } else {
     $exec_aptly_mirror_create_require = [
       Package['aptly'],
-      File['/etc/aptly.conf'],
     ]
   }
 

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -86,7 +86,7 @@ define aptly::mirror (
     ]
   }
 
-  $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
+  $cli_options_string = join(join_keys_to_values($cli_options, '='), ' ')
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title} ${location} ${release} ${components}")
 
   # Since the create and show commands don't share a common set of

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,7 +18,7 @@ define aptly::repo(
 
   $aptly_cmd = "${::aptly::aptly_cmd} repo"
 
-  $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
+  $cli_options_string = join(join_keys_to_values($cli_options, '='), ' ')
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title}")
 
   # Since the create and show commands don't share a common set of

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -21,9 +21,17 @@ define aptly::repo(
   $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title}")
 
+  # Since the create and show commands don't share a common set of
+  # options, we need to extract the config
+  if has_key($cli_options, '-config') {
+    $config_string = "-config=${cli_options['-config']}"
+  } else {
+    $config_string = ''
+  }
+
   exec{ "aptly_repo_create-${title}":
     command => $cmd_string,
-    unless  => "${aptly_cmd} show ${title} >/dev/null",
+    unless  => "${aptly_cmd} show ${config_string} ${title} >/dev/null",
     user    => $::aptly::user,
     require => Package['aptly'],
   }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,67 +6,32 @@
 #
 # === Parameters
 #
-# [*architectures*]
-#   Specify the list of supported architectures as an Array. If ommited Aptly
-#   assumes the repository.
-#
-# [*comment*]
-#   Specifiy a comment to be set for the repository.
-#
-# [*component*]
-#   Specify which component to put the package in. This option will only works
-#   for aptly version >= 0.5.0.
-#
-# [*distribution*]
-#   Specify the default distribution to be used when publishing this repository.
+# [*cli_options*]
+#   Hash containing the command line options that will be passed to aptly.
 
 define aptly::repo(
-  $architectures = [],
-  $comment       = '',
-  $component     = '',
-  $distribution  = '',
+  $cli_options   = {},
 ){
-  validate_array($architectures)
-  validate_string($comment)
-  validate_string($component)
-  validate_string($distribution)
+  validate_hash($cli_options)
+
+  $default_cli_options = {
+    '-architectures' => '',
+    '-comment'       => '',
+    '-component'     => '',
+    '-distribution'  => '',
+  }
 
   include ::aptly
 
   $aptly_cmd = "${::aptly::aptly_cmd} repo"
 
-  if empty($architectures) {
-    $architectures_arg = ''
-  } else{
-    $architectures_as_s = join($architectures, ',')
-    $architectures_arg = "-architectures=\"${architectures_as_s}\""
-  }
-
-  if empty($comment) {
-    $comment_arg = ''
-  } else{
-    $comment_arg = "-comment=\"${comment}\""
-  }
-
-  if empty($component) {
-    $component_arg = ''
-  } else{
-    $component_arg = "-component=\"${component}\""
-  }
-
-  if empty($distribution) {
-    $distribution_arg = ''
-  } else{
-    $distribution_arg = "-distribution=\"${distribution}\""
-  }
+  $cli_options_string = join(reject(join_keys_to_values(merge($default_cli_options, $cli_options), '='), '.*=$'), ' ')
+  $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title}")
 
   exec{ "aptly_repo_create-${title}":
-    command => "${aptly_cmd} create ${architectures_arg} ${comment_arg} ${component_arg} ${distribution_arg} ${title}",
+    command => $cmd_string,
     unless  => "${aptly_cmd} show ${title} >/dev/null",
     user    => $::aptly::user,
-    require => [
-      Package['aptly'],
-      File['/etc/aptly.conf'],
-    ],
+    require => Package['aptly'],
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -14,18 +14,11 @@ define aptly::repo(
 ){
   validate_hash($cli_options)
 
-  $default_cli_options = {
-    '-architectures' => '',
-    '-comment'       => '',
-    '-component'     => '',
-    '-distribution'  => '',
-  }
-
   include ::aptly
 
   $aptly_cmd = "${::aptly::aptly_cmd} repo"
 
-  $cli_options_string = join(reject(join_keys_to_values(merge($default_cli_options, $cli_options), '='), '.*=$'), ' ')
+  $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title}")
 
   exec{ "aptly_repo_create-${title}":

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -22,9 +22,10 @@ define aptly::repo(
   $cmd_string         = rstrip("${aptly_cmd} create ${cli_options_string} ${title}")
 
   # Since the create and show commands don't share a common set of
-  # options, we need to extract the config
-  if has_key($cli_options, '-config') {
-    $config_string = "-config=${cli_options['-config']}"
+  # options, we need to extract the config if it has been specified.
+  $config_path_specified = has_key($cli_options, '-config')
+  if $config_path_specified {
+    $config_string="-config=${cli_options['-config']}"
   } else {
     $config_string = ''
   }

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -24,9 +24,10 @@ define aptly::snapshot (
   $cli_options_string = join(join_keys_to_values($cli_options, '='), ' ')
 
   # Since the create and show commands don't share a common set of
-  # options, we need to extract the config
-  if has_key($cli_options, '-config') {
-    $config_string = "-config=${cli_options['-config']}"
+  # options, we need to extract the config if it has been specified.
+  $config_path_specified = has_key($cli_options, '-config')
+  if $config_path_specified {
+    $config_string="-config=${cli_options['-config']}"
   } else {
     $config_string = ''
   }

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -23,6 +23,14 @@ define aptly::snapshot (
 
   $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
 
+  # Since the create and show commands don't share a common set of
+  # options, we need to extract the config
+  if has_key($cli_options, '-config') {
+    $config_string = "-config=${cli_options['-config']}"
+  } else {
+    $config_string = ''
+  }
+
   if $repo and $mirror {
     fail('$repo and $mirror are mutually exclusive.')
   }
@@ -38,7 +46,7 @@ define aptly::snapshot (
 
   exec { "aptly_snapshot_create-${title}":
     command => "${aptly_cmd} ${cli_options_string} ${aptly_args}",
-    unless  => "${aptly_cmd} ${cli_options_string} show ${title} >/dev/null",
+    unless  => "${aptly_cmd} ${config_string} show ${title} >/dev/null",
     user    => $::aptly::user,
     require => Class['aptly'],
   }

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -11,13 +11,17 @@
 #   Create snapshot from given mirror.
 #
 define aptly::snapshot (
-  $repo   = undef,
-  $mirror = undef,
+  $repo        = undef,
+  $mirror      = undef,
+  $cli_options = {},
 ) {
+  validate_hash($cli_options)
 
   include aptly
 
   $aptly_cmd = "${::aptly::aptly_cmd} snapshot"
+
+  $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
 
   if $repo and $mirror {
     fail('$repo and $mirror are mutually exclusive.')
@@ -33,8 +37,8 @@ define aptly::snapshot (
   }
 
   exec { "aptly_snapshot_create-${title}":
-    command => "${aptly_cmd} ${aptly_args}",
-    unless  => "${aptly_cmd} show ${title} >/dev/null",
+    command => "${aptly_cmd} ${cli_options_string} ${aptly_args}",
+    unless  => "${aptly_cmd} ${cli_options_string} show ${title} >/dev/null",
     user    => $::aptly::user,
     require => Class['aptly'],
   }

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -21,7 +21,7 @@ define aptly::snapshot (
 
   $aptly_cmd = "${::aptly::aptly_cmd} snapshot"
 
-  $cli_options_string = join(reject(join_keys_to_values($cli_options, '='), '.*=$'), ' ')
+  $cli_options_string = join(join_keys_to_values($cli_options, '='), ' ')
 
   # Since the create and show commands don't share a common set of
   # options, we need to extract the config

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
    ],
   "dependencies": [
     {"name": "puppetlabs/stdlib", "version_requirement": ">=4.0.0 <5.0.0"},
-    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 <3.0.0"}
+    {"name": "puppetlabs/apt", "version_requirement": ">=1.0.0 <3.0.0"}
   ],
   "project_page": "https://github.com/gds-operations/puppet-aptly"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -65,6 +65,30 @@ describe 'aptly' do
     end
   end
 
+  describe '#config_dir' do
+    context 'not an absolute path' do
+      let(:params) {{
+        :config_dir  => 'relativepath/aptly.conf.d',
+        :single_root => false,
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not an absolute path/)
+      }
+    end
+
+    context 'custom config path' do
+      let(:params) {{
+        :config_dir  => '/tmp/aptly.conf.d',
+        :single_root => false,
+      }}
+
+      it {
+        should contain_file('/tmp/aptly.conf.d')
+      }
+    end
+  end
+
   describe '#config' do
     context 'not a hash' do
       let(:params) {{

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -114,11 +114,11 @@ EOS
     end
   end
 
-  describe '#create_config' do
+  describe '#single_root' do
     context 'true' do
       let(:params) {{
         :config_contents => '{"rootDir":"/srv/aptly", "architectures":["i386", "amd64"]}',
-        :create_config   => true,
+        :single_root     => true,
       }}
 
       it {
@@ -129,10 +129,11 @@ EOS
     context 'false' do
       let(:params) {{
         :config_contents => '{"rootDir":"/srv/aptly", "architectures":["i386", "amd64"]}',
-        :create_config   => false,
+        :single_root     => false,
       }}
 
       it { should_not contain_file('/etc/aptly.conf') }
+      it { should contain_file('/etc/aptly.conf.d') }
     end
   end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -114,6 +114,28 @@ EOS
     end
   end
 
+  describe '#create_config' do
+    context 'true' do
+      let(:params) {{
+        :config_contents => '{"rootDir":"/srv/aptly", "architectures":["i386", "amd64"]}',
+        :create_config   => true,
+      }}
+
+      it {
+        should contain_file('/etc/aptly.conf').with_content(params[:config_contents])
+      }
+    end
+
+    context 'false' do
+      let(:params) {{
+        :config_contents => '{"rootDir":"/srv/aptly", "architectures":["i386", "amd64"]}',
+        :create_config   => false,
+      }}
+
+      it { should_not contain_file('/etc/aptly.conf') }
+    end
+  end
+
   describe '#repo' do
     context 'not a bool' do
       let(:params) {{

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -314,7 +314,7 @@ describe 'aptly::mirror' do
     it {
       should contain_exec('aptly_mirror_create-example').with({
         :command => /aptly mirror create -with-sources=false -with-udebs=false -force-components=false -config=\/tmp\/aptly.conf example http:\/\/repo\.example\.com precise$/,
-        :unless  => /aptly mirror show example >\/dev\/null$/,
+        :unless  => /aptly mirror show -config=\/tmp\/aptly.conf example >\/dev\/null$/,
         :user    => 'root',
         :require => [
           'Package[aptly]',

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -29,7 +29,6 @@ describe 'aptly::mirror' do
         :user    => 'root',
         :require => [
           'Package[aptly]',
-          'File[/etc/aptly.conf]',
           'Exec[aptly_mirror_gpg-example]'
         ],
       })
@@ -77,7 +76,6 @@ describe 'aptly::mirror' do
           :user    => 'custom_user',
           :require => [
             'Package[aptly]',
-            'File[/etc/aptly.conf]',
             'Exec[aptly_mirror_gpg-example]'
           ],
         })

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -301,4 +301,26 @@ describe 'aptly::mirror' do
       }
     end
   end
+
+  describe 'user defined configuration' do
+    let(:params){{
+      :location => 'http://repo.example.com',
+      :key      => 'ABC123',
+      :cli_options => {
+        '-config' => '/tmp/aptly.conf'
+      }
+    }}
+
+    it {
+      should contain_exec('aptly_mirror_create-example').with({
+        :command => /aptly mirror create -with-sources=false -with-udebs=false -force-components=false -config=\/tmp\/aptly.conf example http:\/\/repo\.example\.com precise$/,
+        :unless  => /aptly mirror show example >\/dev\/null$/,
+        :user    => 'root',
+        :require => [
+          'Package[aptly]',
+          'Exec[aptly_mirror_gpg-example]'
+        ],
+      })
+    }
+  end
 end

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -24,8 +24,8 @@ describe 'aptly::mirror' do
 
     it {
       should contain_exec('aptly_mirror_create-example').with({
-        :command => /aptly -config \/etc\/aptly.conf mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/,
-        :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
+        :command => /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/,
+        :unless  => /aptly mirror show example >\/dev\/null$/,
         :user    => 'root',
         :require => [
           'Package[aptly]',
@@ -72,8 +72,8 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with({
-          :command => /aptly -config \/etc\/aptly.conf mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/,
-          :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
+          :command => /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/,
+          :unless  => /aptly mirror show example >\/dev\/null$/,
           :user    => 'custom_user',
           :require => [
             'Package[aptly]',
@@ -222,7 +222,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise main$/
+          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise main$/
         )
       }
     end
@@ -236,7 +236,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise main contrib non-free$/
+          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise main contrib non-free$/
         )
       }
     end
@@ -268,7 +268,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/
+          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/
         )
       }
     end
@@ -282,7 +282,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/
+          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/
         )
       }
     end
@@ -298,7 +298,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create -with-sources=false -with-udebs=false -force-components=true example http:\/\/repo\.example\.com precise$/
+          /aptly mirror create -with-sources=false -with-udebs=false -force-components=true example http:\/\/repo\.example\.com precise$/
         )
       }
     end

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -240,12 +240,12 @@ describe 'aptly::mirror' do
     end
   end
 
-  describe '#cmd_options' do
+  describe '#cli_options' do
     context 'not a hash' do
       let(:params) {{
         :location    => 'http://repo.example.com',
         :key         => 'ABC123',
-        :cmd_options => 'this is a string',
+        :cli_options => 'this is a string',
       }}
 
       it {
@@ -257,7 +257,7 @@ describe 'aptly::mirror' do
       let(:params) {{
         :location    => 'http://repo.example.com',
         :key         => 'ABC123',
-        :cmd_options => {
+        :cli_options => {
           '-with-sources'     => false,
           '-with-udebs'       => false,
           '-force-components' => false,
@@ -275,7 +275,7 @@ describe 'aptly::mirror' do
       let(:params) {{
         :location    => 'http://repo.example.com',
         :key         => 'ABC123',
-        :cmd_options => {}
+        :cli_options => {}
       }}
 
       it {
@@ -289,7 +289,7 @@ describe 'aptly::mirror' do
       let(:params) {{
         :location    => 'http://repo.example.com',
         :key         => 'ABC123',
-        :cmd_options => {
+        :cli_options => {
           '-force-components' => true,
         }
       }}

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -25,7 +25,7 @@ describe 'aptly::mirror' do
     it {
       should contain_exec('aptly_mirror_create-example').with({
         :command => /aptly mirror create *example http:\/\/repo\.example\.com precise$/,
-        :unless  => /aptly mirror show example >\/dev\/null$/,
+        :unless  => /aptly mirror show *example >\/dev\/null$/,
         :user    => 'root',
         :require => [
           'Package[aptly]',
@@ -72,7 +72,7 @@ describe 'aptly::mirror' do
       it {
         should contain_exec('aptly_mirror_create-example').with({
           :command => /aptly mirror create *example http:\/\/repo\.example\.com precise$/,
-          :unless  => /aptly mirror show example >\/dev\/null$/,
+          :unless  => /aptly mirror show *example >\/dev\/null$/,
           :user    => 'custom_user',
           :require => [
             'Package[aptly]',

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -24,7 +24,7 @@ describe 'aptly::mirror' do
 
     it {
       should contain_exec('aptly_mirror_create-example').with({
-        :command => /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/,
+        :command => /aptly mirror create *example http:\/\/repo\.example\.com precise$/,
         :unless  => /aptly mirror show example >\/dev\/null$/,
         :user    => 'root',
         :require => [
@@ -71,7 +71,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with({
-          :command => /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/,
+          :command => /aptly mirror create *example http:\/\/repo\.example\.com precise$/,
           :unless  => /aptly mirror show example >\/dev\/null$/,
           :user    => 'custom_user',
           :require => [
@@ -220,7 +220,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise main$/
+          /aptly mirror create *example http:\/\/repo\.example\.com precise main$/
         )
       }
     end
@@ -234,7 +234,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise main contrib non-free$/
+          /aptly mirror create *example http:\/\/repo\.example\.com precise main contrib non-free$/
         )
       }
     end
@@ -253,38 +253,6 @@ describe 'aptly::mirror' do
       }
     end
 
-    context 'with valid options' do
-      let(:params) {{
-        :location    => 'http://repo.example.com',
-        :key         => 'ABC123',
-        :cli_options => {
-          '-with-sources'     => false,
-          '-with-udebs'       => false,
-          '-force-components' => false,
-        }
-      }}
-
-      it {
-        should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/
-        )
-      }
-    end
-
-    context 'default options' do
-      let(:params) {{
-        :location    => 'http://repo.example.com',
-        :key         => 'ABC123',
-        :cli_options => {}
-      }}
-
-      it {
-        should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly mirror create -with-sources=false -with-udebs=false -force-components=false example http:\/\/repo\.example\.com precise$/
-        )
-      }
-    end
-
     context 'overriding options' do
       let(:params) {{
         :location    => 'http://repo.example.com',
@@ -296,7 +264,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly mirror create -with-sources=false -with-udebs=false -force-components=true example http:\/\/repo\.example\.com precise$/
+          /aptly mirror create -force-components=true example http:\/\/repo\.example\.com precise$/
         )
       }
     end
@@ -313,7 +281,7 @@ describe 'aptly::mirror' do
 
     it {
       should contain_exec('aptly_mirror_create-example').with({
-        :command => /aptly mirror create -with-sources=false -with-udebs=false -force-components=false -config=\/tmp\/aptly.conf example http:\/\/repo\.example\.com precise$/,
+        :command => /aptly mirror create -config=\/tmp\/aptly.conf example http:\/\/repo\.example\.com precise$/,
         :unless  => /aptly mirror show -config=\/tmp\/aptly.conf example >\/dev\/null$/,
         :user    => 'root',
         :require => [

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -123,7 +123,7 @@ describe 'aptly::repo' do
     it {
       should contain_exec('aptly_repo_create-example').with({
         :command  => /aptly repo create *-config=\/tmp\/aptly.conf *example$/,
-        :unless   => /aptly repo show example >\/dev\/null$/,
+        :unless   => /aptly repo show *-config=\/tmp\/aptly.conf example >\/dev\/null$/,
         :user     => 'root',
         :require  => 'Package[aptly]',
       })

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -12,7 +12,7 @@ describe 'aptly::repo' do
     it {
         should contain_exec('aptly_repo_create-example').with({
           :command  => /aptly repo create *example$/,
-          :unless   => /aptly repo show example >\/dev\/null$/,
+          :unless   => /aptly repo show *example >\/dev\/null$/,
           :user     => 'root',
           :require  => 'Package[aptly]',
       })
@@ -29,7 +29,7 @@ describe 'aptly::repo' do
     it {
         should contain_exec('aptly_repo_create-example').with({
           :command  => /aptly repo create *-component=third-party *example$/,
-          :unless   => /aptly repo show example >\/dev\/null$/,
+          :unless   => /aptly repo show *example >\/dev\/null$/,
           :user     => 'root',
           :require  => 'Package[aptly]',
       })
@@ -52,7 +52,7 @@ describe 'aptly::repo' do
       it {
           should contain_exec('aptly_repo_create-example').with({
             :command  => /aptly repo create *-component=third-party *example$/,
-            :unless   => /aptly repo show example >\/dev\/null$/,
+            :unless   => /aptly repo show *example >\/dev\/null$/,
             :user     => 'custom_user',
             :require  => 'Package[aptly]',
         })
@@ -71,7 +71,7 @@ describe 'aptly::repo' do
       it {
         should contain_exec('aptly_repo_create-example').with({
           :command  => /aptly repo create *-architectures=i386,amd64 *example$/,
-          :unless   => /aptly repo show example >\/dev\/null$/,
+          :unless   => /aptly repo show *example >\/dev\/null$/,
           :user     => 'root',
           :require  => 'Package[aptly]',
         })
@@ -89,7 +89,7 @@ describe 'aptly::repo' do
     it {
       should contain_exec('aptly_repo_create-example').with({
         :command  => /aptly repo create *-comment=example comment *example$/,
-        :unless   => /aptly repo show example >\/dev\/null$/,
+        :unless   => /aptly repo show *example >\/dev\/null$/,
         :user     => 'root',
         :require  => 'Package[aptly]',
       })
@@ -106,7 +106,7 @@ describe 'aptly::repo' do
     it {
       should contain_exec('aptly_repo_create-example').with({
         :command  => /aptly repo create *-distribution=example_distribution *example$/,
-        :unless   => /aptly repo show example >\/dev\/null$/,
+        :unless   => /aptly repo show *example >\/dev\/null$/,
         :user     => 'root',
         :require  => 'Package[aptly]',
       })

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -113,4 +113,20 @@ describe 'aptly::repo' do
     }
   end
 
+  describe 'user defined configuration' do
+    let(:params){{
+      :cli_options => {
+        '-config' => '/tmp/aptly.conf'
+      }
+    }}
+
+    it {
+      should contain_exec('aptly_repo_create-example').with({
+        :command  => /aptly repo create *-config=\/tmp\/aptly.conf *example$/,
+        :unless   => /aptly repo show example >\/dev\/null$/,
+        :user     => 'root',
+        :require  => 'Package[aptly]',
+      })
+    }
+  end
 end

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -11,8 +11,8 @@ describe 'aptly::repo' do
   describe 'param defaults' do
     it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly -config \/etc\/aptly.conf repo create *example$/,
-          :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+          :command  => /aptly repo create *example$/,
+          :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
           :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })
@@ -26,8 +26,8 @@ describe 'aptly::repo' do
 
     it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example$/,
-          :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+          :command  => /aptly repo create *-component="third-party" *example$/,
+          :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
           :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })
@@ -47,8 +47,8 @@ describe 'aptly::repo' do
 
       it {
           should contain_exec('aptly_repo_create-example').with({
-            :command  => /aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example$/,
-            :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+            :command  => /aptly repo create *-component="third-party" *example$/,
+            :unless   => /aptly repo show example >\/dev\/null$/,
             :user     => 'custom_user',
             :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
         })
@@ -64,8 +64,8 @@ describe 'aptly::repo' do
 
       it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly -config \/etc\/aptly.conf repo create *-architectures="i386,amd64" *example$/,
-          :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+          :command  => /aptly repo create *-architectures="i386,amd64" *example$/,
+          :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
           :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
         })
@@ -90,8 +90,8 @@ describe 'aptly::repo' do
 
     it {
       should contain_exec('aptly_repo_create-example').with({
-        :command  => /aptly -config \/etc\/aptly.conf repo create *-comment="example comment" *example$/,
-        :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+        :command  => /aptly repo create *-comment="example comment" *example$/,
+        :unless   => /aptly repo show example >\/dev\/null$/,
         :user     => 'root',
         :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })
@@ -105,8 +105,8 @@ describe 'aptly::repo' do
 
     it {
       should contain_exec('aptly_repo_create-example').with({
-        :command  => /aptly -config \/etc\/aptly.conf repo create *-distribution="example_distribution" *example$/,
-        :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+        :command  => /aptly repo create *-distribution="example_distribution" *example$/,
+        :unless   => /aptly repo show example >\/dev\/null$/,
         :user     => 'root',
         :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -14,22 +14,24 @@ describe 'aptly::repo' do
           :command  => /aptly repo create *example$/,
           :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
-          :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+          :require  => 'Package[aptly]',
       })
     }
   end
 
   describe 'user defined component' do
     let(:params){{
-      :component => 'third-party',
+      :cli_options => {
+        '-component' => 'third-party'
+      }
     }}
 
     it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly repo create *-component="third-party" *example$/,
+          :command  => /aptly repo create *-component=third-party *example$/,
           :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
-          :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+          :require  => 'Package[aptly]',
       })
     }
 
@@ -42,15 +44,17 @@ describe 'aptly::repo' do
       }
 
       let(:params){{
-        :component => 'third-party',
+        :cli_options => {
+          '-component' => 'third-party'
+        }
       }}
 
       it {
           should contain_exec('aptly_repo_create-example').with({
-            :command  => /aptly repo create *-component="third-party" *example$/,
+            :command  => /aptly repo create *-component=third-party *example$/,
             :unless   => /aptly repo show example >\/dev\/null$/,
             :user     => 'custom_user',
-            :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+            :require  => 'Package[aptly]',
         })
       }
     end
@@ -59,56 +63,52 @@ describe 'aptly::repo' do
   describe 'user defined architectures' do
     context 'passing valid values' do
       let(:params){{
-        :architectures => ['i386','amd64'],
+        :cli_options => {
+          '-architectures' => 'i386,amd64',
+        }
       }}
 
       it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly repo create *-architectures="i386,amd64" *example$/,
+          :command  => /aptly repo create *-architectures=i386,amd64 *example$/,
           :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
-          :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+          :require  => 'Package[aptly]',
         })
-      }
-    end
-
-    context 'passing invalid values' do
-      let(:params){{
-        :architectures => 'amd64'
-      }}
-
-      it {
-        should raise_error(Puppet::Error, /is not an Array/)
       }
     end
   end
 
   describe 'user defined comment' do
     let(:params){{
-      :comment => 'example comment',
+      :cli_options => {
+        '-comment' => 'example comment'
+      }
     }}
 
     it {
       should contain_exec('aptly_repo_create-example').with({
-        :command  => /aptly repo create *-comment="example comment" *example$/,
+        :command  => /aptly repo create *-comment=example comment *example$/,
         :unless   => /aptly repo show example >\/dev\/null$/,
         :user     => 'root',
-        :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+        :require  => 'Package[aptly]',
       })
     }
   end
 
   describe 'user defined distribution' do
     let(:params){{
-      :distribution => 'example_distribution',
+      :cli_options => {
+        '-distribution' => 'example_distribution'
+      }
     }}
 
     it {
       should contain_exec('aptly_repo_create-example').with({
-        :command  => /aptly repo create *-distribution="example_distribution" *example$/,
+        :command  => /aptly repo create *-distribution=example_distribution *example$/,
         :unless   => /aptly repo show example >\/dev\/null$/,
         :user     => 'root',
-        :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+        :require  => 'Package[aptly]',
       })
     }
   end

--- a/spec/defines/snapshot_spec.rb
+++ b/spec/defines/snapshot_spec.rb
@@ -11,8 +11,8 @@ describe 'aptly::snapshot' do
   describe 'param defaults' do
     it {
         should contain_exec('aptly_snapshot_create-example').with({
-          :command  => /aptly snapshot create example empty$/,
-          :unless   => /aptly snapshot show example >\/dev\/null$/,
+          :command  => /aptly snapshot *create example empty$/,
+          :unless   => /aptly snapshot *show example >\/dev\/null$/,
           :user     => 'root',
           :require  => 'Class[Aptly]',
       })
@@ -38,8 +38,8 @@ describe 'aptly::snapshot' do
 
       it {
           should contain_exec('aptly_snapshot_create-example').with({
-            :command  => /aptly snapshot create example from repo example_repo$/,
-            :unless   => /aptly snapshot show example >\/dev\/null$/,
+            :command  => /aptly snapshot *create example from repo example_repo$/,
+            :unless   => /aptly snapshot *show example >\/dev\/null$/,
             :user     => 'root',
             :require  => 'Class[Aptly]',
         })
@@ -53,13 +53,30 @@ describe 'aptly::snapshot' do
 
       it {
           should contain_exec('aptly_snapshot_create-example').with({
-            :command  => /aptly snapshot create example from mirror example_mirror$/,
-            :unless   => /aptly snapshot show example >\/dev\/null$/,
+            :command  => /aptly snapshot *create example from mirror example_mirror$/,
+            :unless   => /aptly snapshot *show example >\/dev\/null$/,
             :user     => 'root',
             :require  => 'Class[Aptly]',
         })
       }
     end
 
+    context 'passing cli options' do
+      let(:params){{
+        :mirror   => 'example_mirror',
+        :cli_options => {
+          '-config' => '/tmp/aptly.conf'
+        }
+      }}
+
+      it {
+          should contain_exec('aptly_snapshot_create-example').with({
+            :command  => /aptly snapshot -config=\/tmp\/aptly.conf *create example from mirror example_mirror$/,
+            :unless   => /aptly snapshot -config=\/tmp\/aptly.conf *show example >\/dev\/null$/,
+            :user     => 'root',
+            :require  => 'Class[Aptly]',
+        })
+      }
+    end
   end
 end

--- a/spec/defines/snapshot_spec.rb
+++ b/spec/defines/snapshot_spec.rb
@@ -11,8 +11,8 @@ describe 'aptly::snapshot' do
   describe 'param defaults' do
     it {
         should contain_exec('aptly_snapshot_create-example').with({
-          :command  => /aptly -config \/etc\/aptly.conf snapshot create example empty$/,
-          :unless   => /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null$/,
+          :command  => /aptly snapshot create example empty$/,
+          :unless   => /aptly snapshot show example >\/dev\/null$/,
           :user     => 'root',
           :require  => 'Class[Aptly]',
       })
@@ -38,8 +38,8 @@ describe 'aptly::snapshot' do
 
       it {
           should contain_exec('aptly_snapshot_create-example').with({
-            :command  => /aptly -config \/etc\/aptly.conf snapshot create example from repo example_repo$/,
-            :unless   => /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null$/,
+            :command  => /aptly snapshot create example from repo example_repo$/,
+            :unless   => /aptly snapshot show example >\/dev\/null$/,
             :user     => 'root',
             :require  => 'Class[Aptly]',
         })
@@ -53,8 +53,8 @@ describe 'aptly::snapshot' do
 
       it {
           should contain_exec('aptly_snapshot_create-example').with({
-            :command  => /aptly -config \/etc\/aptly.conf snapshot create example from mirror example_mirror$/,
-            :unless   => /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null$/,
+            :command  => /aptly snapshot create example from mirror example_mirror$/,
+            :unless   => /aptly snapshot show example >\/dev\/null$/,
             :user     => 'root',
             :require  => 'Class[Aptly]',
         })


### PR DESCRIPTION
This patch removes the `config` parameter from the init class and push it to the types so that it can be customized in our calls.

It modifies the parameters of the `github::aptly::repo`, `github::aptly::mirror` and `github::aptly::snapshot` types so that they accept a hash with all the command line options instead of individual parameters, which also has the added benefit of removing the need to update this module should we need to customize another option (or new options were added to aptly).

cc @ross @kpaulisse @rhettg 